### PR TITLE
Add NonNull to deterministic path definitions

### DIFF
--- a/cli/src/Graph/MaterializePath.hs
+++ b/cli/src/Graph/MaterializePath.hs
@@ -186,4 +186,4 @@ materializeNPath firstNid normalizedPath = do
             <&> concatMap (\(bs1', ms) -> (bs1',) <$> ms)
         uptoMidpoints
           & (traverse . _2) (\p -> (p,) <$> traverseBranches p.anchor (toNullable bs2))
-          <&> concatMap (\(bs1', (p, bs2'ts)) -> first (DPSequence (impureNonNull bs1') p . impureNonNull) <$> bs2'ts)
+          <&> concatMap (\(bs1', (p, bs2'ts)) -> first (\bs2' -> DPSequence (impureNonNull bs1') p (impureNonNull bs2')) <$> bs2'ts)

--- a/cli/src/Models/NormalizedPath.hs
+++ b/cli/src/Models/NormalizedPath.hs
@@ -24,8 +24,7 @@ data FullyAnchored
 data DeterministicPath a
   = Rooted (RootedDeterministicPath a)
   | Pointlike (PointlikeDeterministicPath a)
-  deriving stock (Eq, Ord, Show, Generic, Lift)
-  deriving anyclass (NFData)
+  deriving stock (Eq, Ord, Show, Generic)
 
 instance HasField "target" (DeterministicPath a) (PointlikeDeterministicPath a) where
   getField (Rooted p) = p.target
@@ -47,8 +46,7 @@ data RootedDeterministicPath a = RootedDeterministicPath
         ),
     target :: PointlikeDeterministicPath a
   }
-  deriving stock (Eq, Ord, Show, Generic, Lift)
-  deriving anyclass (NFData)
+  deriving stock (Eq, Ord, Show, Generic)
 
 -- | A pointlike deterministic path. This is a path that has a single Root
 -- and the target is the same as the Root.
@@ -59,8 +57,7 @@ data PointlikeDeterministicPath a
     -- | each of these can also be inverted, see `invertLoop` for details
     loops :: OSet (DPBranch a)
   }
-  deriving stock (Eq, Ord, Show, Generic, Lift)
-  deriving anyclass (NFData)
+  deriving stock (Eq, Ord, Show, Generic)
 
 unanchored :: PointlikeDeterministicPath Anchor
 unanchored = PointlikeDeterministicPath Unanchored mempty
@@ -99,12 +96,10 @@ data DPBranch a
       (NonNull (OSet (DPBranch a)))
       (PointlikeDeterministicPath a)
       (NonNull (OSet (DPBranch a)))
-  deriving stock (Eq, Ord, Show, Generic, Lift)
-  deriving anyclass (NFData)
+  deriving stock (Eq, Ord, Show, Generic)
 
 newtype NormalizedPath a = NormalizedPath {union :: Set (DeterministicPath a)}
-  deriving stock (Eq, Ord, Show, Generic, Lift)
-  deriving anyclass (NFData)
+  deriving stock (Eq, Ord, Show, Generic)
 
 pointify ::
   RootedDeterministicPath Anchor ->

--- a/cli/src/Models/NormalizedPath/Parse.hs
+++ b/cli/src/Models/NormalizedPath/Parse.hs
@@ -61,10 +61,12 @@ pRootedPath pNID = label "rooted path" do
 pSequence :: Parser NID -> Parser (DPBranch Anchor)
 pSequence pNID = label "sequence" do
   (initial, splitFirst -> ((m, b), rest)) <- pSequenceBranchSet pNID `via1` pMidpoint
+  let initialNN = impureNonNull initial
+      bNN = impureNonNull b
   pure . uncurry ($) $
     foldl'
-      (\(acc, x) (n, y) -> (acc . impureNonNull . singletonSet . DPSequence (impureNonNull x) n, impureNonNull y))
-      (DPSequence (impureNonNull initial) m :: NonNull (OSet (DPBranch Anchor)) -> DPBranch Anchor, impureNonNull b :: NonNull (OSet (DPBranch Anchor)))
+      (\(acc, x) (n, y) -> (acc . singletonNNSet . DPSequence x n, y))
+      (DPSequence initialNN m :: NonNull (OSet (DPBranch Anchor)) -> DPBranch Anchor, bNN :: NonNull (OSet (DPBranch Anchor)))
       rest
   where
     pMidpoint =

--- a/cli/src/Models/NormalizedPath/ParseSpec.hs
+++ b/cli/src/Models/NormalizedPath/ParseSpec.hs
@@ -135,13 +135,13 @@ singletonBranch :: DPBranch Anchor -> NormalizedPath Anchor
 singletonBranch branch =
   NormalizedPath . singletonSet . Rooted $
     RootedDeterministicPath
-      (singletonMap (Pointlike unanchored) (singletonSet branch))
+      (singletonNNMap (Pointlike unanchored) (singletonNNSet branch))
       unanchored
 
 branches :: [DPBranch Anchor] -> NormalizedPath Anchor
 branches bs =
   NormalizedPath . setFromList $
-    [ Rooted (RootedDeterministicPath (singletonMap (Pointlike unanchored) (singletonSet b)) unanchored)
+    [ Rooted (RootedDeterministicPath (singletonNNMap (Pointlike unanchored) (singletonNNSet b)) unanchored)
     | b <- bs
     ]
 

--- a/cli/src/Models/NormalizedPath/ParseSpec.hs
+++ b/cli/src/Models/NormalizedPath/ParseSpec.hs
@@ -45,10 +45,10 @@ test_pNormalizedPath =
       "[@<a & @1<b & c]>@"
         `parsesTo` singletonRooted
           ( RootedDeterministicPath
-              ( mapFromList
-                  [ (Pointlike joinPoint, singletonSet (DPOutgoing (DPLiteral "a"))),
-                    (Pointlike $ specific (smallNID 1), singletonSet (DPOutgoing (DPLiteral "b"))),
-                    (Pointlike unanchored, singletonSet (DPOutgoing (DPLiteral "c")))
+              ( impureNonNull $ mapFromList
+                  [ (Pointlike joinPoint, singletonNNSet (DPOutgoing (DPLiteral "a"))),
+                    (Pointlike $ specific (smallNID 1), singletonNNSet (DPOutgoing (DPLiteral "b"))),
+                    (Pointlike unanchored, singletonNNSet (DPOutgoing (DPLiteral "c")))
                   ]
               )
               joinPoint

--- a/cli/src/MyPrelude/Collections.hs
+++ b/cli/src/MyPrelude/Collections.hs
@@ -296,7 +296,5 @@ traverseNonNull ::
   (a -> g b) ->
   NonNull (f a) ->
   g (NonNull (f b))
-traverseNonNull f xs = case toList (toNullable xs) of
-  [] -> error "traverseNonNull: impossible - NonNull is empty"
-  (y : ys) -> ncons <$> f y <*> traverse f ys
+traverseNonNull f = fmap impureNonNull . traverse f . toNullable
 

--- a/cli/src/MyPrelude/Collections.hs
+++ b/cli/src/MyPrelude/Collections.hs
@@ -296,5 +296,7 @@ traverseNonNull ::
   (a -> g b) ->
   NonNull (f a) ->
   g (NonNull (f b))
-traverseNonNull f = fmap impureNonNull . traverse f . toNullable
+traverseNonNull f xs = case toList (toNullable xs) of
+  [] -> error "traverseNonNull: impossible - NonNull is empty"
+  (y : ys) -> ncons <$> f y <*> traverse f ys
 

--- a/cli/src/MyPrelude/Collections.hs
+++ b/cli/src/MyPrelude/Collections.hs
@@ -125,6 +125,9 @@ mapSet = Set.map
 mapOSet :: (Ord b) => (a -> b) -> OSet a -> OSet b
 mapOSet f = setFromList . map f . toList
 
+mapOSetNN :: (HasCallStack, Ord b) => (a -> b) -> NonNull (OSet a) -> NonNull (OSet b)
+mapOSetNN f = impureNonNull . mapOSet f . toNullable
+
 mapFromSet :: (Ord k) => Set k -> Map k ()
 mapFromSet = Map.fromSet (const ())
 
@@ -287,3 +290,11 @@ ixsetmapped = iso IxSet.toSet IxSet.fromSet . setmapped
 
 nnmap :: (HasCallStack, MonoFoldable (f b), Functor f) => (a -> b) -> NonNull (f a) -> NonNull (f b)
 nnmap f = impureNonNull . fmap f . toNullable
+
+traverseNonNull ::
+  (HasCallStack, MonoFoldable (g b), Traversable f, Applicative g) =>
+  (a -> g b) ->
+  NonNull (f a) ->
+  g (NonNull (f b))
+traverseNonNull f = fmap impureNonNull . traverse f . toNullable
+

--- a/cli/src/MyPrelude/Collections.hs
+++ b/cli/src/MyPrelude/Collections.hs
@@ -292,7 +292,7 @@ nnmap :: (HasCallStack, MonoFoldable (f b), Functor f) => (a -> b) -> NonNull (f
 nnmap f = impureNonNull . fmap f . toNullable
 
 traverseNonNull ::
-  (HasCallStack, MonoFoldable (g b), Traversable f, Applicative g) =>
+  (HasCallStack, MonoFoldable (f b), Traversable f, Applicative g) =>
   (a -> g b) ->
   NonNull (f a) ->
   g (NonNull (f b))


### PR DESCRIPTION
Updated type definitions to use NonNull for guaranteed non-empty collections:
- RootedDeterministicPath.rootBranches now uses NonNull (OMap ...)
- DPBranch.DPSequence branch sets now use NonNull (OSet ...)

Removed error cases that checked for empty sets:
- Removed "invariant broken: rootBranches must be nonempty" error
- Removed "invariant broken: both branch sets must be nonempty" error

Updated all code using these types to work with NonNull:
- smartBuildSequence now takes NonNull parameters
- smartBuildRootedDeterministicPath now takes NonNull parameters
- branchify returns NonNull sets
- All construction sites wrap with impureNonNull
- Parse functions updated to construct NonNull values
- MaterializePath updated to handle NonNull conversions