### PR TITLE
Add setup note for claude code web stack building

### DIFF
--- a/cli/docs/claude-code-web.md
+++ b/cli/docs/claude-code-web.md
@@ -65,6 +65,7 @@ stack exec graph -- --help
 - Downloads ~200MB of GHC (takes 2-5 minutes)
 - Compiles all dependencies (takes 5-10 minutes)
 - Subsequent builds are much faster (seconds to minutes)
+- **Pro tip:** Start `stack build --fast` in the background immediately after setup, then begin making edits while dependencies compile. Most of the build time is compiling dependencies (not your code), so you can work in parallel.
 
 ## Troubleshooting
 


### PR DESCRIPTION
Adds a note to claude-code-web.md recommending users start stack build in the background immediately after setup. Since most build time is spent compiling dependencies rather than project code, this allows developers to make edits while the initial compilation runs in parallel.